### PR TITLE
Use #blank? instead of #empty?

### DIFF
--- a/app/controllers/chargebee_controller.rb
+++ b/app/controllers/chargebee_controller.rb
@@ -70,7 +70,7 @@ class ChargebeeController < ApplicationController
 
   def check_subscription
     # Ignore events that lack a subscription
-    head :no_content if params.dig("content", "subscription").empty?
+    head :no_content if params.dig("content", "subscription").blank?
   end
 
   def license_signing_key


### PR DESCRIPTION
This fixes the undefined `empty?` for `nil` we're seeing now