### PR TITLE
Return test output in non-subscription webhooks

### DIFF
--- a/app/controllers/chargebee_controller.rb
+++ b/app/controllers/chargebee_controller.rb
@@ -70,7 +70,7 @@ class ChargebeeController < ApplicationController
 
   def check_subscription
     # Ignore events that lack a subscription
-    head :no_content if params.dig("content", "subscription").blank?
+    render plain: "testing" if params.dig("content", "subscription").blank?
   end
 
   def license_signing_key


### PR DESCRIPTION
Turns out for test text to be useful right now it should be in the non-subscription webhooks, since those seem to happen a lot more often