### PR TITLE
Topic/debugging output

### DIFF
--- a/app/controllers/chargebee_controller.rb
+++ b/app/controllers/chargebee_controller.rb
@@ -5,13 +5,12 @@ class ChargebeeController < ApplicationController
   def index
     cb = ChargebeeParse.new(params)
     cb.maybe_update_subscription_and_customer
+    send_domain_emails(cb) and return unless domains_count_ok?(cb)
+
     seed = ENV["LICENSE_SECRET_SEED"]
     key, passphrase = license_signing_key, license_signing_passphrase
 
-    send_domain_emails(cb) and return unless domains_count_ok?(cb)
-    LicenseHandler.call(cb, seed, key, passphrase)
-
-    render plain: "Testing we can see this"
+    render plain: LicenseHandler.call(cb, seed, key, passphrase)
   end
 
   def log_error(e)

--- a/app/controllers/chargebee_controller.rb
+++ b/app/controllers/chargebee_controller.rb
@@ -29,6 +29,8 @@ class ChargebeeController < ApplicationController
   def send_domain_emails(cb)
     if cb.domains_under_min?
       LicenseMailer.domains_under_min(cb.customer_email, cb.listed_domains_max).deliver_now
+      message = cb.message << "Domains under minimum, sent email to #{cb.customer_email}"
+      render plain: message.join("\n")
     elsif cb.domains_over_max?
       raise "Someone tried to register with too many domains"
       # @TODO: not yet implemented
@@ -42,7 +44,7 @@ class ChargebeeController < ApplicationController
 
   def check_subscription
     # Ignore events that lack a subscription
-    render plain: "testing" if params.dig("content", "subscription").blank?
+    render plain: "No subscription given; webhook event: #{webhook_event}" if params.dig("content", "subscription").blank?
   end
 
   def license_signing_key
@@ -51,5 +53,9 @@ class ChargebeeController < ApplicationController
 
   def license_signing_passphrase
     Web::Application.config.license_signing_key_passphrase
+  end
+
+  def webhook_event
+    params["event_type"] || "not given"
   end
 end

--- a/app/models/license_handler.rb
+++ b/app/models/license_handler.rb
@@ -2,12 +2,12 @@ class LicenseHandler
   attr_accessor :message
 
   def initialize(cb, seed, key, passphrase)
+    self.message = cb.message
     @cb = cb
     @seed = seed
     @key = key
     @passphrase = passphrase
     @license_summary = generate_license
-    self.message = []
     @sha = Digest::SHA256.hexdigest(@license_summary[:id_license][:encoded])
   end
 
@@ -16,6 +16,7 @@ class LicenseHandler
     handler.maybe_send_license_email
     handler.update_license_id_and_hash
     handler.upload_to_s3
+    handler.message.join("\n") + "#{ENV['SOURCE_VERSION']}"
   end
 
   # @TODO: handle cancellations
@@ -74,6 +75,7 @@ class LicenseHandler
     s3_uploader = ImazenLicensing::S3::S3LicenseUploader.new(aws_id: aws_id,
                                                              aws_secret: aws_secret)
 
+    self.message << "#{self.class}: uploading license to S3"
     s3_uploader.upload_license(license_id: @license_summary[:id],
                                license_secret: @license_summary[:secret],
                                full_body: @license_summary[:license][:encoded])

--- a/app/models/license_handler.rb
+++ b/app/models/license_handler.rb
@@ -58,12 +58,15 @@ class LicenseHandler
 
   def maybe_send_license_email
     if @sha != @cb.subscription["cf_license_hash"]
+      self.message << "#{self.class}: sending id license email to #{@cb.customer_email}"
       LicenseMailer.id_license_email(
         emails: [@cb.customer_email],
         id_license_encoded: @license_summary[:id_license][:encoded],
         id_license_text: @license_summary[:id_license][:text],
         remote_license_text: @license_summary[:license][:text]
       ).deliver_now
+    else
+      self.message << "#{self.class}: subscription 'cf_license_hash' and checked sha are identical, no email sent"
     end
   end
 

--- a/spec/controllers/chargebee_controller_spec.rb
+++ b/spec/controllers/chargebee_controller_spec.rb
@@ -9,24 +9,38 @@ RSpec.describe ChargebeeController, type: :controller do
   end
 
   context 'subscription_created webhook' do
+    let(:expected_body) {
+      "ChargebeeParse: Retrieved subscription and customer via ChargeBee gem.\nLicenseHandler: sending id license email to test@test.com\nLicenseHandler: fetching subscription IG5ryl2QIcaZIV7QP from ChargeBee API.\nLicenseHandler: posting subscription IG5ryl2QIcaZIV7QP back to ChargeBee API.\nLicenseHandler: uploading license to S3"
+    }
+
     it 'returns success response' do
       VCR.use_cassette("subscription_created") do
         post :index, params: load_chargebee_params('subscription_created')
         expect(response).to have_http_status :success
+        expect(response.body).to eq expected_body
       end
     end
 
     context 'subscription requires domains' do
       context 'domains count is ok' do
+        let(:expected_body) {
+          "ChargebeeParse: Retrieved subscription and customer via ChargeBee gem.\nLicenseHandler: sending id license email to shelley@example.com\nLicenseHandler: fetching subscription JFIJqVlRYy4RlKoGJ from ChargeBee API.\nLicenseHandler: posting subscription JFIJqVlRYy4RlKoGJ back to ChargeBee API.\nLicenseHandler: uploading license to S3"
+        }
+
         it 'does not send domain emails' do
           VCR.use_cassette('domains_count_ok') do
             expect(LicenseMailer).not_to receive(:domains_under_min)
             post :index, params: load_chargebee_params('domains_count_ok')
+            expect(response.body).to eq expected_body
           end
         end
       end
 
       context 'domains count is under minimum' do
+        let(:expected_body) {
+          "ChargebeeParse: Retrieved subscription and customer via ChargeBee gem.\nDomains under minimum, sent email to shelley@example.com"
+        }
+
         it 'sends domains_under_min email' do
           VCR.use_cassette('domains_under_min') do
             # expect the correct mailer method to be called, then stub out
@@ -47,8 +61,7 @@ RSpec.describe ChargebeeController, type: :controller do
           VCR.use_cassette('domains_under_min') do
             post :index, params: load_chargebee_params('domains_under_min')
             expect(response).to have_http_status :success
-            expect(response.body).to include("Retrieved subscription")
-            expect(response.body).to include("Domains under minimum")
+            expect(response.body).to eq expected_body
           end
         end
       end

--- a/spec/models/chargebee_parse_spec.rb
+++ b/spec/models/chargebee_parse_spec.rb
@@ -105,4 +105,38 @@ RSpec.describe 'ChargebeeParse' do
       end
     end
   end
+
+  describe '#message' do
+    subject { cb.message }
+
+    it { is_expected.to be_a(Array) }
+
+    context 'after trying to update subscription and customer' do
+      context 'with a stale subscription' do
+        before do
+          allow(cb).to receive(:subscription_stale?).and_return(true)
+          allow(ChargeBee::Subscription).to receive(:retrieve).and_return(double(subscription: {}))
+          allow(ChargeBee::Customer).to receive(:retrieve).and_return(double(customer: {}))
+          cb.maybe_update_subscription_and_customer
+        end
+
+        it 'includes a string containing log info' do
+          expect(subject).to include(a_string_matching(/Retrieved/))
+          expect(subject).to include(a_string_matching(/subscription/))
+          expect(subject).to include(a_string_matching(/customer/))
+        end
+      end
+
+      context 'with a subscription that is not stale' do
+        before do
+          allow(cb).to receive(:subscription_stale?).and_return(false)
+          cb.maybe_update_subscription_and_customer
+        end
+
+        it 'includes a string containing log info' do
+          expect(subject).to include(a_string_matching(/skipping/))
+        end
+      end
+    end
+  end
 end

--- a/spec/models/license_handler_spec.rb
+++ b/spec/models/license_handler_spec.rb
@@ -128,12 +128,18 @@ RSpec.describe LicenseHandler do
   end
 
   describe '#upload_to_s3' do
-    before { allow(ImazenLicensing::S3::S3LicenseUploader).to receive(:new).and_return(fake_uploader)  }
+    before do
+      allow(ImazenLicensing::S3::S3LicenseUploader).to receive(:new).and_return(fake_uploader)
+      handler.upload_to_s3
+    end
     let(:fake_uploader) { double(upload_license: true) }
 
     it 'calls upload_license' do
-      expect(fake_uploader).to receive(:upload_license)
-      handler.upload_to_s3
+      expect(fake_uploader).to have_received(:upload_license)
+    end
+
+    it 'logs the upload' do
+      expect(handler.message).to include(a_string_matching(/uploading license to S3/))
     end
   end
 end

--- a/spec/models/license_handler_spec.rb
+++ b/spec/models/license_handler_spec.rb
@@ -62,7 +62,11 @@ RSpec.describe LicenseHandler do
       allow(HTTParty).to receive(:post)
       handler.update_license_id_and_hash
     end
-    let(:response) { double }
+    let(:response) { double(ok?: true, fetch: {}) }
+
+    it 'logs the subscription fetch' do
+      expect(handler.message).to include(a_string_matching(/fetching subscription/))
+    end
 
     context 'when a successful api response includes a subscription' do
       let(:response) { double(ok?: true, fetch: subscription) }
@@ -72,6 +76,10 @@ RSpec.describe LicenseHandler do
 
         it 'posts the new subscription to the api' do
           expect(HTTParty).to have_received(:post)
+        end
+
+        it 'logs the subscription posting' do
+          expect(handler.message).to include(a_string_matching(/posting subscription/))
         end
       end
 
@@ -83,6 +91,11 @@ RSpec.describe LicenseHandler do
 
         it 'does not post to the api' do
           expect(HTTParty).to_not have_received(:post)
+        end
+
+        it 'logs that we did not post the subscription' do
+          expect(handler.message).to include(a_string_matching(/license unchanged for subscription/))
+          expect(handler.message).to include(a_string_matching(/no post to ChargeBee/))
         end
       end
     end


### PR DESCRIPTION
So here's the debugging output part, to address issue #20. I think we'll probably find that we're fetching subscriptions and uploading licenses a bit more often than expected. I'm curious whether we can replace the [direct `HTTParty` requests](https://github.com/imazen/licensing/pull/24/files#diff-56d66a433f28cf43408811871b5de9c6R38) to use the ChargeBee gem (or just the data that we got when we initially fetched the subscription via the gem) but I didn't want to change that functionality without going over it with you more carefully to make sure I'm not missing something.