### PR TITLE
Actually log messages to the Rails/Heroku logs

### DIFF
--- a/app/controllers/chargebee_controller.rb
+++ b/app/controllers/chargebee_controller.rb
@@ -10,7 +10,9 @@ class ChargebeeController < ApplicationController
     seed = ENV["LICENSE_SECRET_SEED"]
     key, passphrase = license_signing_key, license_signing_passphrase
 
-    render plain: LicenseHandler.call(cb, seed, key, passphrase)
+    result_log = LicenseHandler.call(cb, seed, key, passphrase)
+    logger.info(result_log)
+    render plain: result_log
   end
 
   def log_error(e)


### PR DESCRIPTION
While checking the event logs on Chargebee and the Heroku logs, I realized the result message was only being returned in the response and not logged, so we can't look at it unless we rerun the webhook in chargebee. This explicitly logs it  so we can look at it in the Rails/Heroku logs.